### PR TITLE
Run XSpec tests in Maven

### DIFF
--- a/.github/workflows/maven.yml
+++ b/.github/workflows/maven.yml
@@ -1,0 +1,35 @@
+# This workflow will build a Java project with Maven, and cache/restore any dependencies to improve the workflow execution time
+# For more information see: https://docs.github.com/en/actions/automating-builds-and-tests/building-and-testing-java-with-maven
+
+# This workflow uses actions that are not certified by GitHub.
+# They are provided by a third-party and are governed by
+# separate terms of service, privacy policy, and support
+# documentation.
+
+name: Run XSpec tests with Maven
+
+on:
+  push:
+    branches: [ "main" ]
+  pull_request:
+    branches: [ "main" ]
+
+jobs:
+  build:
+
+    runs-on: ubuntu-latest
+
+    steps:
+    - uses: actions/checkout@v3
+    - name: Set up JDK 11
+      uses: actions/setup-java@v3
+      with:
+        java-version: '11'
+        distribution: 'temurin'
+        cache: maven
+    - name: Build with Maven
+      run: mvn -B package --file pom.xml
+
+    # Optional: Uploads the full dependency graph to GitHub to improve the quality of Dependabot alerts this repository can receive
+    #- name: Update dependency graph
+    #  uses: advanced-security/maven-dependency-submission-action@571e99aab1055c2e71a1e2309b9691de18d6b7d6

--- a/.gitignore
+++ b/.gitignore
@@ -1,2 +1,3 @@
+target/
 *-report.html
 *-result.html

--- a/pom.xml
+++ b/pom.xml
@@ -1,0 +1,65 @@
+<project xmlns="http://maven.apache.org/POM/4.0.0"
+    xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+    xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/xsd/maven-4.0.0.xsd">
+    <modelVersion>4.0.0</modelVersion>
+    <groupId>com.galtm</groupId>
+    <artifactId>xslt-accumulator-tools</artifactId>
+    <version>0.1.0-SNAPSHOT</version>
+    <name>XSLT Accumulator Tools</name>
+    <description>Tools for debugging and testing XSLT accumulators</description>
+    <scm>
+        <url>https://github.com/galtm/xslt-accumulator-tools</url>
+        <developerConnection>scm:git:https://github.com/galtm/xslt-accumulator-tools</developerConnection>
+        <tag>HEAD</tag>
+    </scm>
+    <properties>
+        <saxon.version>11.5</saxon.version>
+    </properties>
+    <build>
+        <plugins>
+            <!-- "mvn test" runs XSpec tests -->
+            <!-- https://github.com/nkutsche/xspec-maven-plugin does not seem to have
+                the issue logged in https://github.com/xspec/xspec-maven-plugin-1/issues/65 -->
+            <plugin>
+                <groupId>com.nkutsche</groupId>
+                <artifactId>xspec-maven-plugin</artifactId>
+                <version>2.0.0</version>
+                <executions>
+                    <execution>
+                        <id>run-xspec</id>
+                        <goals>
+                            <goal>run-xspec</goal>
+                        </goals>
+                        <phase>test</phase>
+                    </execution>
+                </executions>
+                <dependencies>
+                    <dependency>
+                        <groupId>net.sf.saxon</groupId>
+                        <artifactId>Saxon-HE</artifactId>
+                        <version>${saxon.version}</version>
+                    </dependency>
+                    <dependency>
+                        <groupId>io.xspec</groupId>
+                        <artifactId>xspec</artifactId>
+                        <version>2.2.4</version>
+                        <classifier>enduser-files</classifier>
+                        <type>zip</type>
+                    </dependency>
+                </dependencies>
+                <configuration>
+                    <addDependenciesToClasspath>true</addDependenciesToClasspath>
+                    <generateSurefireReport>true</generateSurefireReport>
+                    <testDir>${project.basedir}</testDir>
+                    <includes>
+                        <include>sample-acc/test/*.xspec</include>
+                        <include>test/*.xspec</include>
+                    </includes>
+                    <excludes>
+                        <exclude>test/maven-helper.xspec</exclude>
+                    </excludes>
+                </configuration>
+            </plugin>
+        </plugins>
+    </build>
+</project>

--- a/test/acc-report-inclusion.xspec
+++ b/test/acc-report-inclusion.xspec
@@ -10,6 +10,7 @@
     xslt-version="3.0">
 
     <x:helper stylesheet="acc-indent-level-modified.xsl"/>
+    <x:import href="maven-helper.xspec"><!-- Defines $av:path-prefix --></x:import>
 
     <x:param name="at:acc-decl-uri" as="xs:string" select="'test/acc-indent-level-modified.xsl'"/>
     <x:param name="at:acc-name" as="xs:string" select="'indent-level-modified'"/>
@@ -352,7 +353,7 @@
         </x:scenario>
         <x:scenario label="acc-name with URI-qualified name">
             <x:call template="at:show-declaration">
-                <x:param name="acc-decl-uri" select="resolve-uri('../acc-duplicate.xsl')"/>
+                <x:param name="acc-decl-uri" select="resolve-uri($av:path-prefix || 'acc-duplicate.xsl')"/>
                 <x:param name="acc-name" select="'Q{http://github.com/galtm/xslt-accumulator-tools}acc2'"/>
             </x:call>
             <x:expect label="Sanity-check accumulator declaration code to confirm it was found"
@@ -375,7 +376,7 @@
                 </x:context>
                 <x:call template="at:truncated-text-or-comment"/>
                 <x:expect label="Indentation followed by full text content"
-                    select="'&#160;&#160;&#160;&#160;' || 
+                    select="'&#160;&#160;&#160;&#160;' ||
                     '123456789 123456789 123456789 123456789 123456789 1234567890'"/>
             </x:scenario>
             <x:scenario label="whose content exceeds truncation limit">
@@ -402,9 +403,9 @@
                 </x:context>
                 <x:call template="at:truncated-text-or-comment"/>
                 <x:expect label="Indentation, comment start, full text content, comment end"
-                    select="'&#160;&#160;&#160;&#160;' || 
-                    '&lt;!--' || 
-                    '123456789 123456789 123456789 123456789 123456789 1234567890' || 
+                    select="'&#160;&#160;&#160;&#160;' ||
+                    '&lt;!--' ||
+                    '123456789 123456789 123456789 123456789 123456789 1234567890' ||
                     '-->'"/>
             </x:scenario>
             <x:scenario label="whose content exceeds truncation limit">
@@ -415,8 +416,8 @@
                 <x:expect label="Indentation, comment start, truncated text content, ellipsis, comment end"
                     select="'&#160;&#160;&#160;&#160;' ||
                     '&lt;!--' ||
-                    '123456789 123456789 123456789 123456789 123456789 1234567890' || 
-                    '...' || 
+                    '123456789 123456789 123456789 123456789 123456789 1234567890' ||
+                    '...' ||
                     '-->'"/>
             </x:scenario>
         </x:scenario>
@@ -453,7 +454,7 @@
                 <h:span class="attrval">"1"</h:span>
                 <h:span class="attrname"> attr2=</h:span>
                 <h:span class="attrval">"2"</h:span>
-            </x:expect> 
+            </x:expect>
         </x:scenario>
         <x:scenario label="Empty sequence as input">
             <x:call function="at:list-attrs">
@@ -480,7 +481,7 @@
         </x:scenario>
     </x:scenario>
 
-    <!-- 
+    <!--
     This file is part of xslt-accumulator-tools.
 
     xslt-accumulator-tools is free software: you can redistribute it and/or modify it under the terms of the GNU Affero General Public License as published by the Free Software Foundation, either version 3 of the License, or (at your option) any later version.

--- a/test/acc-reporter.xspec
+++ b/test/acc-reporter.xspec
@@ -10,9 +10,9 @@
     stylesheet="../acc-reporter.xsl"
     xslt-version="3.0">
 
-    <x:helper stylesheet="acc-indent-level-modified.xsl"/>
+    <x:import href="maven-helper.xspec"><!-- Defines $av:path-prefix --></x:import>
 
-    <x:param name="at:acc-decl-uri" as="xs:string" select="resolve-uri('../acc-indent-level-modified.xsl')"/>
+    <x:param name="at:acc-decl-uri" as="xs:string" select="resolve-uri($av:path-prefix || 'acc-indent-level-modified.xsl')"/>
     <x:param name="at:acc-name" as="xs:string" select="'indent-level-modified'"/>
 
     <x:variable name="av:tree" href="node-types.xml" as="document-node()"/>
@@ -24,9 +24,9 @@
                 test="exists(/h:html/h:body/h:table//h:td[.='Document node start'])"/>
         </x:scenario>
         <x:scenario label="Check that error-checking is performed here" catch="yes">
-            <x:context select="$av:tree">
-                <x:param name="at:acc-name" select="'nonexistent'"/>
-            </x:context>
+            <!-- Scenario-level override of global XSLT parameter requires run-as="external" -->
+            <x:param name="at:acc-name" select="'nonexistent'"/>
+            <x:context select="$av:tree"/>
             <x:expect label="Error"
                 test="$x:result instance of map(*) and $x:result('err') instance of map(*)"/>
         </x:scenario>
@@ -91,7 +91,7 @@
     <x:scenario label="Tests for at:error-checking template">
         <x:scenario label="Non-error case">
             <x:call template="at:error-checking">
-                <x:param name="acc-decl-uri" select="resolve-uri('../acc-indent-level-modified.xsl')"/>
+                <x:param name="acc-decl-uri" select="resolve-uri($av:path-prefix || 'acc-indent-level-modified.xsl')"/>
                 <x:param name="acc-name" select="$at:acc-name"/>
             </x:call>
             <x:expect label="Empty sequence and no error" select="()"/>
@@ -109,7 +109,7 @@
         </x:scenario>
         <x:scenario label="Accumulator not found" catch="yes">
             <x:call template="at:error-checking">
-                <x:param name="acc-decl-uri" select="resolve-uri('../acc-indent-level-modified.xsl')"/>
+                <x:param name="acc-decl-uri" select="resolve-uri($av:path-prefix || 'acc-indent-level-modified.xsl')"/>
                 <x:param name="acc-name" select="'nonexistent'"/>
             </x:call>
             <x:expect label="Error"
@@ -120,7 +120,7 @@
         </x:scenario>
         <x:scenario label="Duplicate accumulator found" catch="yes">
             <x:call template="at:error-checking">
-                <x:param name="acc-decl-uri" select="resolve-uri('../acc-duplicate.xsl')"/>
+                <x:param name="acc-decl-uri" select="resolve-uri($av:path-prefix || 'acc-duplicate.xsl')"/>
                 <x:param name="acc-name" select="'Q{http://github.com/galtm/xslt-accumulator-tools}acc'"/>
             </x:call>
             <x:expect label="Error"
@@ -131,7 +131,7 @@
         </x:scenario>
     </x:scenario>
 
-    <!-- 
+    <!--
     This file is part of xslt-accumulator-tools.
 
     xslt-accumulator-tools is free software: you can redistribute it and/or modify it under the terms of the GNU Affero General Public License as published by the Free Software Foundation, either version 3 of the License, or (at your option) any later version.

--- a/test/maven-helper.xspec
+++ b/test/maven-helper.xspec
@@ -1,0 +1,25 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<x:description
+    xmlns:x="http://www.jenitennison.com/xslt/xspec"
+    xmlns:xs="http://www.w3.org/2001/XMLSchema"
+    xmlns:av="http://github.com/galtm/xslt-accumulator-tools/variables"
+    stylesheet="../acc-reporter.xsl"
+    xslt-version="3.0">
+
+    <x:variable name="av:path-prefix" as="xs:string"
+        select="if (static-base-uri() => contains('/target/') (: Maven copies XSpec files to target/ :) )
+        then '../../../test/'
+        else '../'"
+    />
+
+    <!--
+    This file is part of xslt-accumulator-tools.
+
+    xslt-accumulator-tools is free software: you can redistribute it and/or modify it under the terms of the GNU Affero General Public License as published by the Free Software Foundation, either version 3 of the License, or (at your option) any later version.
+
+    xslt-accumulator-tools is distributed in the hope that it will be useful, but WITHOUT ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the GNU Affero General Public License for more details.
+
+    You should have received a copy of the GNU Affero General Public License along with xslt-accumulator-tools. If not, see <https://www.gnu.org/licenses/>.
+    -->
+
+</x:description>


### PR DESCRIPTION
Each pull request in this repo should automatically run all the XSpec tests in `test/` and `sample-acc/test/`.

c3795d6b63df0cbf9ec6ddc2cee1010b24789204 is based on the "Java with Maven" starter workflow from GitHub Actions.

pom.xml uses the Maven plug-in at https://github.com/nkutsche/xspec-maven-plugin because it does not have the issue logged in https://github.com/xspec/xspec-maven-plugin-1/issues/65.

Locally, a developer can install Maven on a supported platform and run `mvn test` from the top-level directory of this repo.
