### PR TITLE
Remove unneeded `xsl:mode` element

### DIFF
--- a/acc-reporter.xsl
+++ b/acc-reporter.xsl
@@ -19,9 +19,6 @@
     <!-- IMPORTS -->
     <xsl:import href="lib/xspec/src/compiler/base/util/compiler-eqname-utils.xsl"/>
 
-    <!-- MODES -->
-    <xsl:mode name="at:acc-view" use-accumulators="#all"/>
-
     <!-- ALIASES -->
     <xsl:namespace-alias stylesheet-prefix="genxsl" result-prefix="xsl"/>
 


### PR DESCRIPTION
This transform does not apply templates in the `at:acc-view` mode (but rather calls an external transform to do so). This file doesn't need `xsl:mode` for the `at:acc-view` mode.
