### PR TITLE
Rename parameter for URI of top-level XSLT file

### DIFF
--- a/README.md
+++ b/README.md
@@ -24,7 +24,7 @@ The `src/acc-reporter.xsl` stylesheet requires the following information that yo
 |---|---|---|
 | Accumulator name  | `$at:acc-name`  |  `<?acc-name my-accumulator-name?>` |
 | URI of XSLT file containing accumulator declaration, relative to the XML file's base URI  | `$at:acc-decl-uri` | `<?acc-decl-uri my-accumulator-declaration-uri?>` |
-| URI of top-level XSLT module, if different from the file containing the accumulator declaration, relative to the XML file's base URI | `$at:acc-parent-uri` | `<?acc-parent-uri my-main-xslt-uri?>`  |
+| URI of top-level XSLT module, if different from the file containing the accumulator declaration, relative to the XML file's base URI | `$at:acc-toplevel-uri` | `<?acc-toplevel-uri my-main-xslt-uri?>`  |
 
 
 In the notation above, the `at` prefix is associated with the `http://github.com/galtm/xslt-accumulator-tools` namespace.
@@ -46,7 +46,7 @@ From your clone of this repository, you can execute a command like the following
 
 The file `section-with-elements.xml` contains processing instructions that identify the relevant XSLT modules and the accumulator name, so the command above does not need to pass in any global parameter values. In the absence of those processing instructions, your command would have looked like this:
 
-`java -cp "...path to Saxon jar file..." net.sf.saxon.Transform -t -s:src/sample-acc/sample-xml/section-with-elements.xml -xsl:src/acc-reporter.xsl -o:section-with-elements-report.html {http://github.com/galtm/xslt-accumulator-tools}acc-name=Q{my-acc-ns}element-count {http://github.com/galtm/xslt-accumulator-tools}acc-decl-uri=../acc-decl-not-standalone.xsl {http://github.com/galtm/xslt-accumulator-tools}acc-parent-uri=../parent.xsl`
+`java -cp "...path to Saxon jar file..." net.sf.saxon.Transform -t -s:src/sample-acc/sample-xml/section-with-elements.xml -xsl:src/acc-reporter.xsl -o:section-with-elements-report.html {http://github.com/galtm/xslt-accumulator-tools}acc-name=Q{my-acc-ns}element-count {http://github.com/galtm/xslt-accumulator-tools}acc-decl-uri=../acc-decl-not-standalone.xsl {http://github.com/galtm/xslt-accumulator-tools}acc-toplevel-uri=../parent.xsl`
 
 ### Variation: Generating Report Based on Tree Not in XML File
 You can generate an HTML report of accumulator values associated with nodes of a tree that your XSLT stylesheet defines in a variable, even if the tree is not saved to an XML file. In this situation, you do the following:

--- a/src/acc-report-inclusion.xsl
+++ b/src/acc-report-inclusion.xsl
@@ -185,7 +185,7 @@
 
     <xsl:template match="processing-instruction()" mode="at:acc-view"
         expand-text="1" as="element(h:tr)?">
-        <xsl:if test="not(name(.)=('acc-decl-uri','acc-name','acc-parent-uri'))">
+        <xsl:if test="not(name(.)=('acc-decl-uri','acc-name','acc-toplevel-uri'))">
             <tr>
                 <td>
                     <span class="pi">

--- a/src/acc-reporter.xsl
+++ b/src/acc-reporter.xsl
@@ -11,7 +11,7 @@
     <!-- PARAMETERS -->
     <xsl:param name="at:acc-decl-uri" as="xs:string?"/>
     <xsl:param name="at:acc-name" as="xs:string?"/>
-    <xsl:param name="at:acc-parent-uri" as="xs:string?"/>
+    <xsl:param name="at:acc-toplevel-uri" as="xs:string?"/>
 
     <xsl:param name="at:skip-whitespace" as="xs:boolean" select="true()"/>
     <xsl:param name="at:trunc" as="xs:integer" select="60"/>
@@ -32,11 +32,11 @@
             select="if ($at:acc-name != '')
             then $at:acc-name
             else processing-instruction(acc-name)/normalize-space()"/>
-        <xsl:param name="acc-parent-uri" as="xs:string?"
-            select="(if ($at:acc-parent-uri != '')
-            then $at:acc-parent-uri
-            else if (processing-instruction(acc-parent-uri)/normalize-space())
-            then processing-instruction(acc-parent-uri)/normalize-space()
+        <xsl:param name="acc-toplevel-uri" as="xs:string?"
+            select="(if ($at:acc-toplevel-uri != '')
+            then $at:acc-toplevel-uri
+            else if (processing-instruction(acc-toplevel-uri)/normalize-space())
+            then processing-instruction(acc-toplevel-uri)/normalize-space()
             else ())
             => resolve-uri(base-uri())"/>
 
@@ -48,7 +48,7 @@
             <xsl:call-template name="at:transform-options">
                 <xsl:with-param name="acc-decl-uri" select="$acc-decl-uri"/>
                 <xsl:with-param name="acc-name" select="$acc-name"/>
-                <xsl:with-param name="acc-parent-uri" select="$acc-parent-uri"/>
+                <xsl:with-param name="acc-toplevel-uri" select="$acc-toplevel-uri"/>
                 <xsl:with-param name="source" select="."/>
             </xsl:call-template>
         </xsl:variable>
@@ -59,7 +59,7 @@
     <xsl:template name="at:transform-options" as="map(xs:string, item()*)">
         <xsl:param name="acc-decl-uri" as="xs:string"/>
         <xsl:param name="acc-name" as="xs:string"/>
-        <xsl:param name="acc-parent-uri" as="xs:string?"/>
+        <xsl:param name="acc-toplevel-uri" as="xs:string?"/>
         <xsl:param name="source" as="document-node()"/>
         <xsl:variable name="combined-transform" as="element()">
             <genxsl:transform version="3.0" exclude-result-prefixes="#all">
@@ -71,7 +71,7 @@
                     <xsl:namespace name="xs" select="'http://www.w3.org/2001/XMLSchema'"/>
                 </genxsl:param>
                 <genxsl:include href="acc-report-inclusion.xsl"/>
-                <genxsl:import href="{($acc-parent-uri,$acc-decl-uri)[1]}"/>
+                <genxsl:import href="{($acc-toplevel-uri,$acc-decl-uri)[1]}"/>
             </genxsl:transform>
         </xsl:variable>
         <xsl:variable name="transform-options" as="map(xs:string, item()*)">

--- a/src/sample-acc/sample-xml/glossary.xml
+++ b/src/sample-acc/sample-xml/glossary.xml
@@ -1,7 +1,7 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <?acc-decl-uri ../glossary.xsl?>
 <?acc-name glossentry-position?>
-<?acc-parent-uri ../tree-report-example.xsl?>
+<?acc-toplevel-uri ../tree-report-example.xsl?>
 <?xml-model href="http://docbook.org/xml/5.1/rng/docbook.rng" schematypens="http://relaxng.org/ns/structure/1.0"?>
 <?xml-model href="http://docbook.org/xml/5.1/sch/docbook.sch" type="application/xml" schematypens="http://purl.oclc.org/dsdl/schematron"?>
 <glossary xmlns="http://docbook.org/ns/docbook" version="5.1">

--- a/src/sample-acc/sample-xml/section-with-elements.xml
+++ b/src/sample-acc/sample-xml/section-with-elements.xml
@@ -1,7 +1,7 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <?acc-decl-uri ../acc-decl-not-standalone.xsl?>
 <?acc-name Q{my-acc-ns}element-count?>
-<?acc-parent-uri ../parent.xsl?>
+<?acc-toplevel-uri ../parent.xsl?>
 <section>
     <title>Sample Title</title>
     <para>Sample content</para>

--- a/src/test/acc-report-inclusion.xspec
+++ b/src/test/acc-report-inclusion.xspec
@@ -264,8 +264,8 @@
             <x:context mode="at:acc-view" select="/processing-instruction()"><?acc-name xyz?></x:context>
             <x:expect label="Empty sequence" select="()"/>
         </x:scenario>
-        <x:scenario label="Special PI 'acc-parent-uri'">
-            <x:context mode="at:acc-view" select="/processing-instruction()"><?acc-parent-uri xyz?></x:context>
+        <x:scenario label="Special PI 'acc-toplevel-uri'">
+            <x:context mode="at:acc-view" select="/processing-instruction()"><?acc-toplevel-uri xyz?></x:context>
             <x:expect label="Empty sequence" select="()"/>
         </x:scenario>
         <x:scenario label="Typical user-defined processing instruction">

--- a/src/test/acc-reporter.xspec
+++ b/src/test/acc-reporter.xspec
@@ -33,7 +33,7 @@
         <x:scenario label="$at:generate-tree-report=true in XSLT does not cause an error (because generated XSLT overrides that parameter)">
             <!-- Scenario-level override of global XSLT parameters requires run-as="external" -->
             <x:param name="at:acc-decl-uri" select="resolve-uri($av:path-prefix || '../sample-acc/glossary.xsl')"/>
-            <x:param name="at:acc-parent-uri" select="resolve-uri($av:path-prefix || '../sample-acc/tree-report-example.xsl')"/>
+            <x:param name="at:acc-toplevel-uri" select="resolve-uri($av:path-prefix || '../sample-acc/tree-report-example.xsl')"/>
             <x:param name="at:acc-name" select="'glossentry-position'"/>
             <x:context select="doc(resolve-uri($av:path-prefix || '../sample-acc/sample-xml/glossary.xml'))"/>
             <x:expect label="Sanity-check result" test="/h:html/h:body/h:h1">
@@ -51,7 +51,7 @@
 
     <x:scenario label="Tests for at:transform-options template">
         <x:variable name="av:ns" as="xs:string" select="'http://github.com/galtm/xslt-accumulator-tools'"/>
-        <x:scenario label="Accumulator declaration is in top-level XSLT file, so acc-parent-uri is omitted">
+        <x:scenario label="Accumulator declaration is in top-level XSLT file, so acc-toplevel-uri is omitted">
             <x:call template="at:transform-options">
                 <x:param name="acc-decl-uri" select="'user-xslt.xsl'"/>
                 <x:param name="acc-name" select="'name'"/>
@@ -80,11 +80,11 @@
                     QName($av:ns,'at:acc-decl-uri')
                 )"/>
         </x:scenario>
-        <x:scenario label="Accumulator declaration is in subordinate XSLT file, so acc-parent-uri is provided separately">
+        <x:scenario label="Accumulator declaration is in subordinate XSLT file, so acc-toplevel-uri is provided separately">
             <x:call template="at:transform-options">
                 <x:param name="acc-decl-uri" select="'user-xslt-with-accumulator-declaration.xsl'"/>
                 <x:param name="acc-name" select="'name'"/>
-                <x:param name="acc-parent-uri" select="'user-main-xslt.xsl'"/>
+                <x:param name="acc-toplevel-uri" select="'user-main-xslt.xsl'"/>
                 <x:param name="source" select="$av:tree"/>
             </x:call>
             <x:expect label="Stylesheet includes acc-report-inclusion.xsl and imports parent XSLT"
@@ -92,7 +92,7 @@
                 self::xsl:transform[@version='3.0']/
                 xsl:include[@href='acc-report-inclusion.xsl']/
                 following-sibling::xsl:import[@href='user-main-xslt.xsl'])"/>
-            <x:expect label="Stylesheet parameters are as expected (and do not include at:acc-parent-uri)"
+            <x:expect label="Stylesheet parameters are as expected (and do not include at:acc-toplevel-uri)"
                 test="$x:result('stylesheet-params') => map:keys()"
                 select="(
                 QName($av:ns,'at:acc-name'),


### PR DESCRIPTION
Use 'acc-toplevel-uri' instead of 'acc-parent-uri' because the accumulator declaration might be
multiple levels deep in an XSLT file hierarchy.
