### PR TITLE
Avoid ambiguous match for PI accumulator rules

### DIFF
--- a/src/test/acc-indent-level-modified.xsl
+++ b/src/test/acc-indent-level-modified.xsl
@@ -8,9 +8,9 @@
     <xsl:mode use-accumulators="indent-level-modified"/>
 
     <xsl:accumulator name="indent-level-modified" as="xs:integer" initial-value="0">
-        <xsl:accumulator-rule match="element() | text() | comment() | processing-instruction()"
+        <xsl:accumulator-rule match="element() | text() | comment() | processing-instruction()[not(name(.)=('no-indent','add-ten'))]"
             select="$value + 1"/>
-        <xsl:accumulator-rule match="element() | text() | comment() | processing-instruction()"
+        <xsl:accumulator-rule match="element() | text() | comment() | processing-instruction()[not(name(.)=('no-indent','add-ten'))]"
             phase="end"
             select="$value - 1"/>
 


### PR DESCRIPTION
In an accumulator used for testing purposes, avoid an ambiguous rule match.