### PR TITLE
Move global params out of namespace

### DIFF
--- a/README.md
+++ b/README.md
@@ -22,14 +22,14 @@ The `src/acc-reporter.xsl` stylesheet requires the following information that yo
 
 | Item | XSLT Parameter | Processing Instruction  |
 |---|---|---|
-| Accumulator name  | `$at:acc-name`  |  `<?acc-name my-accumulator-name?>` |
-| URI of XSLT file containing accumulator declaration, relative to the XML file's base URI  | `$at:acc-decl-uri` | `<?acc-decl-uri my-accumulator-declaration-uri?>` |
-| URI of top-level XSLT module, if different from the file containing the accumulator declaration, relative to the XML file's base URI | `$at:acc-toplevel-uri` | `<?acc-toplevel-uri my-main-xslt-uri?>`  |
+| Accumulator name  | `$acc-name`  |  `<?acc-name my-accumulator-name?>` |
+| URI of XSLT file containing accumulator declaration, relative to the XML file's base URI  | `$acc-decl-uri` | `<?acc-decl-uri my-accumulator-declaration-uri?>` |
+| URI of top-level XSLT module, if different from the file containing the accumulator declaration, relative to the XML file's base URI | `$acc-toplevel-uri` | `<?acc-toplevel-uri my-main-xslt-uri?>`  |
 
 
 In the notation above, the `at` prefix is associated with the `http://github.com/galtm/xslt-accumulator-tools` namespace.
 
-If your accumulator's name is in a namespace with URI `foo`, you can use notation `Q{foo}my-accumulator-name` in the value of the `$at:acc-name` XSLT parameter or the `acc-name` processing instruction.
+If your accumulator's name is in a namespace with URI `foo`, you can use notation `Q{foo}my-accumulator-name` in the value of the `$acc-name` XSLT parameter or the `acc-name` processing instruction.
 
 ### Oxygen XML Editor Instructions
 
@@ -46,7 +46,7 @@ From your clone of this repository, you can execute a command like the following
 
 The file `section-with-elements.xml` contains processing instructions that identify the relevant XSLT modules and the accumulator name, so the command above does not need to pass in any global parameter values. In the absence of those processing instructions, your command would have looked like this:
 
-`java -cp "...path to Saxon jar file..." net.sf.saxon.Transform -t -s:src/sample-acc/sample-xml/section-with-elements.xml -xsl:src/acc-reporter.xsl -o:section-with-elements-report.html {http://github.com/galtm/xslt-accumulator-tools}acc-name=Q{my-acc-ns}element-count {http://github.com/galtm/xslt-accumulator-tools}acc-decl-uri=../acc-decl-not-standalone.xsl {http://github.com/galtm/xslt-accumulator-tools}acc-toplevel-uri=../parent.xsl`
+`java -cp "...path to Saxon jar file..." net.sf.saxon.Transform -t -s:src/sample-acc/sample-xml/section-with-elements.xml -xsl:src/acc-reporter.xsl -o:section-with-elements-report.html acc-name=Q{my-acc-ns}element-count acc-decl-uri=../acc-decl-not-standalone.xsl acc-toplevel-uri=../parent.xsl`
 
 ### Variation: Generating Report Based on Tree Not in XML File
 You can generate an HTML report of accumulator values associated with nodes of a tree that your XSLT stylesheet defines in a variable, even if the tree is not saved to an XML file. In this situation, you do the following:

--- a/src/acc-reporter.xsl
+++ b/src/acc-reporter.xsl
@@ -9,9 +9,9 @@
     version="3.0">
 
     <!-- PARAMETERS -->
-    <xsl:param name="at:acc-decl-uri" as="xs:string?"/>
-    <xsl:param name="at:acc-name" as="xs:string?"/>
-    <xsl:param name="at:acc-toplevel-uri" as="xs:string?"/>
+    <xsl:param name="acc-decl-uri" as="xs:string?"/>
+    <xsl:param name="acc-name" as="xs:string?"/>
+    <xsl:param name="acc-toplevel-uri" as="xs:string?"/>
 
     <xsl:param name="at:skip-whitespace" as="xs:boolean" select="true()"/>
     <xsl:param name="at:trunc" as="xs:integer" select="60"/>
@@ -23,32 +23,32 @@
     <xsl:namespace-alias stylesheet-prefix="genxsl" result-prefix="xsl"/>
 
     <xsl:template match="/" as="element()">
-        <xsl:param name="acc-decl-uri" as="xs:string"
-            select="(if ($at:acc-decl-uri != '')
-            then $at:acc-decl-uri
-            else processing-instruction(acc-decl-uri)/normalize-space())
+        <xsl:param name="acc-decl-uri-local" as="xs:string"
+            select="(if ($acc-decl-uri != '')
+            then $acc-decl-uri
+            else processing-instruction('acc-decl-uri')/normalize-space())
             => resolve-uri(base-uri())"/>
-        <xsl:param name="acc-name" as="xs:string"
-            select="if ($at:acc-name != '')
-            then $at:acc-name
-            else processing-instruction(acc-name)/normalize-space()"/>
-        <xsl:param name="acc-toplevel-uri" as="xs:string?"
-            select="(if ($at:acc-toplevel-uri != '')
-            then $at:acc-toplevel-uri
-            else if (processing-instruction(acc-toplevel-uri)/normalize-space())
-            then processing-instruction(acc-toplevel-uri)/normalize-space()
+        <xsl:param name="acc-name-local" as="xs:string"
+            select="if ($acc-name != '')
+            then $acc-name
+            else processing-instruction('acc-name')/normalize-space()"/>
+        <xsl:param name="acc-toplevel-uri-local" as="xs:string?"
+            select="(if ($acc-toplevel-uri != '')
+            then $acc-toplevel-uri
+            else if (processing-instruction('acc-toplevel-uri')/normalize-space())
+            then processing-instruction('acc-toplevel-uri')/normalize-space()
             else ())
             => resolve-uri(base-uri())"/>
 
         <xsl:call-template name="at:error-checking">
-            <xsl:with-param name="acc-decl-uri" select="$acc-decl-uri"/>
-            <xsl:with-param name="acc-name" select="$acc-name"/>
+            <xsl:with-param name="acc-decl-uri" select="$acc-decl-uri-local"/>
+            <xsl:with-param name="acc-name" select="$acc-name-local"/>
         </xsl:call-template>
         <xsl:variable name="transform-options" as="map(xs:string, item()*)">
             <xsl:call-template name="at:transform-options">
-                <xsl:with-param name="acc-decl-uri" select="$acc-decl-uri"/>
-                <xsl:with-param name="acc-name" select="$acc-name"/>
-                <xsl:with-param name="acc-toplevel-uri" select="$acc-toplevel-uri"/>
+                <xsl:with-param name="acc-decl-uri" select="$acc-decl-uri-local"/>
+                <xsl:with-param name="acc-name" select="$acc-name-local"/>
+                <xsl:with-param name="acc-toplevel-uri" select="$acc-toplevel-uri-local"/>
                 <xsl:with-param name="source" select="."/>
             </xsl:call-template>
         </xsl:variable>

--- a/src/test/acc-reporter.xspec
+++ b/src/test/acc-reporter.xspec
@@ -12,8 +12,8 @@
 
     <x:import href="maven-helper.xspec"><!-- Defines $av:path-prefix --></x:import>
 
-    <x:param name="at:acc-decl-uri" as="xs:string" select="resolve-uri($av:path-prefix || 'acc-indent-level-modified.xsl')"/>
-    <x:param name="at:acc-name" as="xs:string" select="'indent-level-modified'"/>
+    <x:param name="acc-decl-uri" as="xs:string" select="resolve-uri($av:path-prefix || 'acc-indent-level-modified.xsl')"/>
+    <x:param name="acc-name" as="xs:string" select="'indent-level-modified'"/>
 
     <x:variable name="av:tree" href="node-types.xml" as="document-node()"/>
 
@@ -25,16 +25,16 @@
         </x:scenario>
         <x:scenario label="Check that error-checking is performed here" catch="yes">
             <!-- Scenario-level override of global XSLT parameter requires run-as="external" -->
-            <x:param name="at:acc-name" select="'nonexistent'"/>
+            <x:param name="acc-name" select="'nonexistent'"/>
             <x:context select="$av:tree"/>
             <x:expect label="Error"
                 test="$x:result instance of map(*) and $x:result('err') instance of map(*)"/>
         </x:scenario>
         <x:scenario label="$at:generate-tree-report=true in XSLT does not cause an error (because generated XSLT overrides that parameter)">
             <!-- Scenario-level override of global XSLT parameters requires run-as="external" -->
-            <x:param name="at:acc-decl-uri" select="resolve-uri($av:path-prefix || '../sample-acc/glossary.xsl')"/>
-            <x:param name="at:acc-toplevel-uri" select="resolve-uri($av:path-prefix || '../sample-acc/tree-report-example.xsl')"/>
-            <x:param name="at:acc-name" select="'glossentry-position'"/>
+            <x:param name="acc-decl-uri" select="resolve-uri($av:path-prefix || '../sample-acc/glossary.xsl')"/>
+            <x:param name="acc-toplevel-uri" select="resolve-uri($av:path-prefix || '../sample-acc/tree-report-example.xsl')"/>
+            <x:param name="acc-name" select="'glossentry-position'"/>
             <x:context select="doc(resolve-uri($av:path-prefix || '../sample-acc/sample-xml/glossary.xml'))"/>
             <x:expect label="Sanity-check result" test="/h:html/h:body/h:h1">
                 <h:h1>Values of glossentry-position Accumulator for Tree in glossary.xml</h:h1>
@@ -110,14 +110,14 @@
         <x:scenario label="Non-error case">
             <x:call template="at:error-checking">
                 <x:param name="acc-decl-uri" select="resolve-uri($av:path-prefix || 'acc-indent-level-modified.xsl')"/>
-                <x:param name="acc-name" select="$at:acc-name"/>
+                <x:param name="acc-name" select="$acc-name"/>
             </x:call>
             <x:expect label="Empty sequence and no error" select="()"/>
         </x:scenario>
         <x:scenario label="XSLT file not found" catch="yes">
             <x:call template="at:error-checking">
                 <x:param name="acc-decl-uri" select="'nonexistent'"/>
-                <x:param name="acc-name" select="$at:acc-name"/>
+                <x:param name="acc-name" select="$acc-name"/>
             </x:call>
             <x:expect label="Error"
                 test="$x:result instance of map(*) and $x:result('err') instance of map(*)"/>


### PR DESCRIPTION
At command line, it's awkward for end users to specify the namespace of global parameters of acc-reporter.xsl. Move the parameters out of a namespace to simplify the user's transformation command.

(`acc-report-inclusion.xsl` still uses namespaced global parameters to avoid conflict with the user's own XSLT code.)
