### PR TITLE
Use exactly-one to ensure nonempty context for accumulator function

### DIFF
--- a/src/sample-acc/test/internal-elem-dedicated.xspec
+++ b/src/sample-acc/test/internal-elem-dedicated.xspec
@@ -18,15 +18,20 @@
             label="At end of subsection remark, 1 element name in stack"
             test="$myv:tree/section/section/remark/accumulator-after('internal-elem')"
             select="('section')"/>
+        <!--
+            Use of exactly-one() ensures that if $myv:tree yields an empty sequence
+            by mistake, you'll get an error instead of having the accumulator function
+            return empty for the wrong reason.
+        -->
         <x:expect
             label="At end of document, stack is empty"
-            test="$myv:tree/accumulator-after('internal-elem')"
+            test="exactly-one($myv:tree)/accumulator-after('internal-elem')"
             select="()"/>
 
         <!-- Variation: Boolean @test and no @select -->
         <x:expect
             label="At end of document, stack is empty"
-            test="empty($myv:tree/accumulator-after('internal-elem'))"/>
+            test="empty(exactly-one($myv:tree)/accumulator-after('internal-elem'))"/>
     </x:scenario>
 
     <!-- 

--- a/src/test/acc-report-inclusion.xspec
+++ b/src/test/acc-report-inclusion.xspec
@@ -61,8 +61,13 @@
             </x:variable>
             <x:call function="true"/>
             <x:like label="at:prior-value accumulator values for nodes other than document node"/>
+            <!--
+                Use of exactly-one() ensures that if $av:tree/self::document-node() yields an empty sequence
+                by mistake, you'll get an error instead of having the accumulator function
+                return empty for the wrong reason.
+            -->
             <x:expect label="At start of document node, result is () because there is no prior value"
-                test="$av:tree/self::document-node()/accumulator-before('at:prior-value')"
+                test="exactly-one($av:tree/self::document-node())/accumulator-before('at:prior-value')"
                 select="()"/>
             <x:expect label="At end of document node, prior indent level is 0"
                 test="$av:tree/self::document-node()/accumulator-after('at:prior-value')"


### PR DESCRIPTION
Update checks for accumulator values where the expected value is an empty sequence.

If the context at which you call an accumulator function yields an empty sequence by mistake, you'll now get an error instead of having an incorrectly passing test result where the accumulator function returns empty for the wrong reason.

Separately, I updated the Balisage paper's excerpt from `internal-elem-dedicated.xspec` in the latest version that I plan to send to the conference organizers next month.
