### PR TITLE
Upgrade XSpec from v2.2 to v2.3

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -90,7 +90,7 @@
                     <dependency>
                         <groupId>io.xspec</groupId>
                         <artifactId>xspec</artifactId>
-                        <version>2.2.4</version>
+                        <version>2.3.2</version>
                         <classifier>enduser-files</classifier>
                         <type>zip</type>
                     </dependency>


### PR DESCRIPTION
### Notes

This pull request upgrades the version of XSpec used in GitHub Actions, now that XSpec v2.3 has been released.

### Checklist

- [ ] Have you followed the guidelines in our [Contributing](https://github.com/galtm/xslt-accumulator-tools/blob/main/CONTRIBUTING.md) document?
- [x] Have you checked to ensure there aren't other open [Pull Requests](https://github.com/galtm/xslt-accumulator-tools/pulls) for the same update/change?
- [x] Have you squashed any irrelevant commits and commit messages? \[[instructions](https://git-scm.com/book/en/v2/Git-Tools-Rewriting-History)\]
- [x] Do all automated CI/CD checks pass?
