### PR TITLE
Bump xspec-maven-plugin from 2.0.0 to 2.0.1

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -71,7 +71,7 @@
             <plugin>
                 <groupId>com.nkutsche</groupId>
                 <artifactId>xspec-maven-plugin</artifactId>
-                <version>2.0.0</version>
+                <version>2.0.1</version>
                 <executions>
                     <execution>
                         <id>run-xspec</id>


### PR DESCRIPTION
### Notes

This pull request updates the Maven test runner to get the fix for https://github.com/nkutsche/xspec-maven-plugin/issues/7

### Checklist

- [ ] Have you followed the guidelines in our [Contributing](https://github.com/galtm/xslt-accumulator-tools/blob/main/CONTRIBUTING.md) document?
- [x] Have you checked to ensure there aren't other open [Pull Requests](https://github.com/galtm/xslt-accumulator-tools/pulls) for the same update/change?
- [x] Have you squashed any irrelevant commits and commit messages? \[[instructions](https://git-scm.com/book/en/v2/Git-Tools-Rewriting-History)\]
- [x] Do all automated CI/CD checks pass?
