### PR TITLE
Upgrade XSpec from v3.1.2 to v3.1.3

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -90,7 +90,7 @@
                     <dependency>
                         <groupId>io.xspec</groupId>
                         <artifactId>xspec</artifactId>
-                        <version>3.1.2</version>
+                        <version>3.1.3</version>
                         <classifier>enduser-files</classifier>
                         <type>zip</type>
                     </dependency>


### PR DESCRIPTION
### Notes
This PR updates the XSpec version used to run tests in this repo, from v3.1.2 to v3.1.3. The difference doesn't really affect this repo, but I use this repo as a test case to make sure the new XSpec release works.

### Checklist

- [ ] Have you followed the guidelines in our [Contributing](https://github.com/galtm/xslt-accumulator-tools/blob/main/CONTRIBUTING.md) document?
- [ ] Have you checked to ensure there aren't other open [Pull Requests](https://github.com/galtm/xslt-accumulator-tools/pulls) for the same update/change?
- [ ] Have you squashed any irrelevant commits and commit messages? \[[instructions](https://git-scm.com/book/en/v2/Git-Tools-Rewriting-History)\]
- [ ] Do all automated CI/CD checks pass?
