### PR TITLE
Add badge showing test status

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,5 +1,7 @@
 # XSLT Accumulator Tools
 
+[![Run XSpec tests with Maven](https://github.com/galtm/xslt-accumulator-tools/actions/workflows/maven.yml/badge.svg)](https://github.com/galtm/xslt-accumulator-tools/actions/workflows/maven.yml)
+
 Utilities for exploring and testing XSLT accumulators, to complement the Balisage 2023 conference presentation, [Accumulators in XSLT and XSpec: Developing, Debugging, and Testing XSLT 3 Accumulators](https://balisage.net/Proceedings/vol28/html/Galtman01/BalisageVol28-Galtman01.html).
 
 - [Report of Accumulator Values](#report-of-accumulator-values)


### PR DESCRIPTION
### Notes

This PR adds a badge to this repo's main README document, showing the status of automated testing. I got the markup for the badge by following instructions in the GitHub doc. I tried the URL in a browser, and the result looks like this:

![image](https://github.com/user-attachments/assets/c3724728-3ce9-4ed9-8ed5-06b224549f82)


### Checklist

- [ ] Have you followed the guidelines in our [Contributing](https://github.com/galtm/xslt-accumulator-tools/blob/main/CONTRIBUTING.md) document?
- [x] Have you checked to ensure there aren't other open [Pull Requests](https://github.com/galtm/xslt-accumulator-tools/pulls) for the same update/change?
- [x] Have you squashed any irrelevant commits and commit messages? \[[instructions](https://git-scm.com/book/en/v2/Git-Tools-Rewriting-History)\]
- [ ] Do all automated CI/CD checks pass?
