### PR TITLE
Remove comment about AGPL license in code files

### DIFF
--- a/src/acc-report-inclusion.xsl
+++ b/src/acc-report-inclusion.xsl
@@ -392,14 +392,4 @@
             '.../' || $repo-sample-acc)"/>
     </xsl:function>
 
-    <!--
-    This file is part of xslt-accumulator-tools.
-
-    xslt-accumulator-tools is free software: you can redistribute it and/or modify it under the terms of the GNU Affero General Public License as published by the Free Software Foundation, either version 3 of the License, or (at your option) any later version.
-
-    xslt-accumulator-tools is distributed in the hope that it will be useful, but WITHOUT ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the GNU Affero General Public License for more details.
-
-    You should have received a copy of the GNU Affero General Public License along with xslt-accumulator-tools. If not, see <https://www.gnu.org/licenses/>.
-    -->
-
 </xsl:stylesheet>

--- a/src/acc-reporter.xsl
+++ b/src/acc-reporter.xsl
@@ -171,14 +171,4 @@
         </xsl:choose>
     </xsl:template>
 
-    <!--
-    This file is part of xslt-accumulator-tools.
-
-    xslt-accumulator-tools is free software: you can redistribute it and/or modify it under the terms of the GNU Affero General Public License as published by the Free Software Foundation, either version 3 of the License, or (at your option) any later version.
-
-    xslt-accumulator-tools is distributed in the hope that it will be useful, but WITHOUT ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the GNU Affero General Public License for more details.
-
-    You should have received a copy of the GNU Affero General Public License along with xslt-accumulator-tools. If not, see <https://www.gnu.org/licenses/>.
-    -->
-
 </xsl:stylesheet>

--- a/src/accumulator-test-tools.xsl
+++ b/src/accumulator-test-tools.xsl
@@ -49,13 +49,4 @@
         <xsl:sequence select="$context/fn:accumulator-after($name)"/>
     </xsl:function>
 
-    <!-- 
-    This file is part of xslt-accumulator-tools.
-
-    xslt-accumulator-tools is free software: you can redistribute it and/or modify it under the terms of the GNU Affero General Public License as published by the Free Software Foundation, either version 3 of the License, or (at your option) any later version.
-
-    xslt-accumulator-tools is distributed in the hope that it will be useful, but WITHOUT ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the GNU Affero General Public License for more details.
-
-    You should have received a copy of the GNU Affero General Public License along with xslt-accumulator-tools. If not, see <https://www.gnu.org/licenses/>.
-    -->
 </xsl:transform>

--- a/src/sample-acc/test/internal-elem-dedicated.xspec
+++ b/src/sample-acc/test/internal-elem-dedicated.xspec
@@ -34,14 +34,4 @@
             test="empty(exactly-one($myv:tree)/accumulator-after('internal-elem'))"/>
     </x:scenario>
 
-    <!-- 
-    This file is part of xslt-accumulator-tools.
-
-    xslt-accumulator-tools is free software: you can redistribute it and/or modify it under the terms of the GNU Affero General Public License as published by the Free Software Foundation, either version 3 of the License, or (at your option) any later version.
-
-    xslt-accumulator-tools is distributed in the hope that it will be useful, but WITHOUT ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the GNU Affero General Public License for more details.
-
-    You should have received a copy of the GNU Affero General Public License along with xslt-accumulator-tools. If not, see <https://www.gnu.org/licenses/>.
-    -->
-
 </x:description>

--- a/src/sample-acc/test/internal-elem-external-harness.xspec
+++ b/src/sample-acc/test/internal-elem-external-harness.xspec
@@ -41,13 +41,4 @@
         </x:scenario>
     </x:scenario>
 
-    <!--
-    This file is part of xslt-accumulator-tools.
-
-    xslt-accumulator-tools is free software: you can redistribute it and/or modify it under the terms of the GNU Affero General Public License as published by the Free Software Foundation, either version 3 of the License, or (at your option) any later version.
-
-    xslt-accumulator-tools is distributed in the hope that it will be useful, but WITHOUT ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the GNU Affero General Public License for more details.
-
-    You should have received a copy of the GNU Affero General Public License along with xslt-accumulator-tools. If not, see <https://www.gnu.org/licenses/>.
-    -->
 </x:description>

--- a/src/sample-acc/test/internal-elem-external.xspec
+++ b/src/sample-acc/test/internal-elem-external.xspec
@@ -35,13 +35,4 @@
         </x:scenario>
     </x:scenario>
 
-    <!-- 
-    This file is part of xslt-accumulator-tools.
-
-    xslt-accumulator-tools is free software: you can redistribute it and/or modify it under the terms of the GNU Affero General Public License as published by the Free Software Foundation, either version 3 of the License, or (at your option) any later version.
-
-    xslt-accumulator-tools is distributed in the hope that it will be useful, but WITHOUT ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the GNU Affero General Public License for more details.
-
-    You should have received a copy of the GNU Affero General Public License along with xslt-accumulator-tools. If not, see <https://www.gnu.org/licenses/>.
-    -->
 </x:description>

--- a/src/sample-acc/test/internal-elem-integrated.xspec
+++ b/src/sample-acc/test/internal-elem-integrated.xspec
@@ -26,13 +26,4 @@
             select="('remark', 'section')"/>
     </x:scenario>
 
-    <!-- 
-    This file is part of xslt-accumulator-tools.
-
-    xslt-accumulator-tools is free software: you can redistribute it and/or modify it under the terms of the GNU Affero General Public License as published by the Free Software Foundation, either version 3 of the License, or (at your option) any later version.
-
-    xslt-accumulator-tools is distributed in the hope that it will be useful, but WITHOUT ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the GNU Affero General Public License for more details.
-
-    You should have received a copy of the GNU Affero General Public License along with xslt-accumulator-tools. If not, see <https://www.gnu.org/licenses/>.
-    -->
 </x:description>

--- a/src/sample-acc/tree-report-example.xsl
+++ b/src/sample-acc/tree-report-example.xsl
@@ -88,13 +88,4 @@
 
     </xsl:template>
 
-    <!--
-    This file is part of xslt-accumulator-tools.
-
-    xslt-accumulator-tools is free software: you can redistribute it and/or modify it under the terms of the GNU Affero General Public License as published by the Free Software Foundation, either version 3 of the License, or (at your option) any later version.
-
-    xslt-accumulator-tools is distributed in the hope that it will be useful, but WITHOUT ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the GNU Affero General Public License for more details.
-
-    You should have received a copy of the GNU Affero General Public License along with xslt-accumulator-tools. If not, see <https://www.gnu.org/licenses/>.
-    -->
 </xsl:stylesheet>

--- a/src/test/acc-duplicate.xsl
+++ b/src/test/acc-duplicate.xsl
@@ -22,14 +22,4 @@
         <xsl:accumulator-rule match="*" select="$value + 1"/>
     </xsl:accumulator>
 
-    <!-- 
-    This file is part of xslt-accumulator-tools.
-
-    xslt-accumulator-tools is free software: you can redistribute it and/or modify it under the terms of the GNU Affero General Public License as published by the Free Software Foundation, either version 3 of the License, or (at your option) any later version.
-
-    xslt-accumulator-tools is distributed in the hope that it will be useful, but WITHOUT ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the GNU Affero General Public License for more details.
-
-    You should have received a copy of the GNU Affero General Public License along with xslt-accumulator-tools. If not, see <https://www.gnu.org/licenses/>.
-    -->
-
 </xsl:stylesheet>

--- a/src/test/acc-indent-level-modified.xsl
+++ b/src/test/acc-indent-level-modified.xsl
@@ -22,14 +22,4 @@
         <xsl:accumulator-rule match="processing-instruction(add-ten)" phase="end" select="$value"/>
     </xsl:accumulator>
 
-    <!-- 
-    This file is part of xslt-accumulator-tools.
-
-    xslt-accumulator-tools is free software: you can redistribute it and/or modify it under the terms of the GNU Affero General Public License as published by the Free Software Foundation, either version 3 of the License, or (at your option) any later version.
-
-    xslt-accumulator-tools is distributed in the hope that it will be useful, but WITHOUT ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the GNU Affero General Public License for more details.
-
-    You should have received a copy of the GNU Affero General Public License along with xslt-accumulator-tools. If not, see <https://www.gnu.org/licenses/>.
-    -->
-
 </xsl:stylesheet>

--- a/src/test/acc-info.xsl
+++ b/src/test/acc-info.xsl
@@ -43,14 +43,4 @@
         </xsl:choose>
     </xsl:template>
 
-    <!-- 
-    This file is part of xslt-accumulator-tools.
-
-    xslt-accumulator-tools is free software: you can redistribute it and/or modify it under the terms of the GNU Affero General Public License as published by the Free Software Foundation, either version 3 of the License, or (at your option) any later version.
-
-    xslt-accumulator-tools is distributed in the hope that it will be useful, but WITHOUT ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the GNU Affero General Public License for more details.
-
-    You should have received a copy of the GNU Affero General Public License along with xslt-accumulator-tools. If not, see <https://www.gnu.org/licenses/>.
-    -->
-
 </xsl:stylesheet>

--- a/src/test/acc-report-inclusion.xspec
+++ b/src/test/acc-report-inclusion.xspec
@@ -523,14 +523,4 @@
             select="1"/>
     </x:scenario>
 
-    <!--
-    This file is part of xslt-accumulator-tools.
-
-    xslt-accumulator-tools is free software: you can redistribute it and/or modify it under the terms of the GNU Affero General Public License as published by the Free Software Foundation, either version 3 of the License, or (at your option) any later version.
-
-    xslt-accumulator-tools is distributed in the hope that it will be useful, but WITHOUT ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the GNU Affero General Public License for more details.
-
-    You should have received a copy of the GNU Affero General Public License along with xslt-accumulator-tools. If not, see <https://www.gnu.org/licenses/>.
-    -->
-
 </x:description>

--- a/src/test/acc-reporter.xspec
+++ b/src/test/acc-reporter.xspec
@@ -139,14 +139,4 @@
         </x:scenario>
     </x:scenario>
 
-    <!--
-    This file is part of xslt-accumulator-tools.
-
-    xslt-accumulator-tools is free software: you can redistribute it and/or modify it under the terms of the GNU Affero General Public License as published by the Free Software Foundation, either version 3 of the License, or (at your option) any later version.
-
-    xslt-accumulator-tools is distributed in the hope that it will be useful, but WITHOUT ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the GNU Affero General Public License for more details.
-
-    You should have received a copy of the GNU Affero General Public License along with xslt-accumulator-tools. If not, see <https://www.gnu.org/licenses/>.
-    -->
-
 </x:description>

--- a/src/test/accumulator-test-tools-external.xspec
+++ b/src/test/accumulator-test-tools-external.xspec
@@ -142,14 +142,4 @@
         </x:scenario>
     </x:scenario>
 
-    <!-- 
-    This file is part of xslt-accumulator-tools.
-
-    xslt-accumulator-tools is free software: you can redistribute it and/or modify it under the terms of the GNU Affero General Public License as published by the Free Software Foundation, either version 3 of the License, or (at your option) any later version.
-
-    xslt-accumulator-tools is distributed in the hope that it will be useful, but WITHOUT ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the GNU Affero General Public License for more details.
-
-    You should have received a copy of the GNU Affero General Public License along with xslt-accumulator-tools. If not, see <https://www.gnu.org/licenses/>.
-    -->
-
 </x:description>

--- a/src/test/accumulator-test-tools-import.xspec
+++ b/src/test/accumulator-test-tools-import.xspec
@@ -140,14 +140,4 @@
         </x:scenario>
     </x:scenario>
 
-    <!-- 
-    This file is part of xslt-accumulator-tools.
-
-    xslt-accumulator-tools is free software: you can redistribute it and/or modify it under the terms of the GNU Affero General Public License as published by the Free Software Foundation, either version 3 of the License, or (at your option) any later version.
-
-    xslt-accumulator-tools is distributed in the hope that it will be useful, but WITHOUT ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the GNU Affero General Public License for more details.
-
-    You should have received a copy of the GNU Affero General Public License along with xslt-accumulator-tools. If not, see <https://www.gnu.org/licenses/>.
-    -->
-
 </x:description>

--- a/src/test/maven-helper.xspec
+++ b/src/test/maven-helper.xspec
@@ -12,14 +12,4 @@
         else '../'"
     />
 
-    <!--
-    This file is part of xslt-accumulator-tools.
-
-    xslt-accumulator-tools is free software: you can redistribute it and/or modify it under the terms of the GNU Affero General Public License as published by the Free Software Foundation, either version 3 of the License, or (at your option) any later version.
-
-    xslt-accumulator-tools is distributed in the hope that it will be useful, but WITHOUT ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the GNU Affero General Public License for more details.
-
-    You should have received a copy of the GNU Affero General Public License along with xslt-accumulator-tools. If not, see <https://www.gnu.org/licenses/>.
-    -->
-
 </x:description>


### PR DESCRIPTION
### Notes

Following up from #35, this PR removes code comments that refer to the AGPL license. Those comments are no longer relevant to the files because the files are now covered under the MIT license.

### Checklist

- [ ] Have you followed the guidelines in our [Contributing](https://github.com/galtm/xslt-accumulator-tools/blob/main/CONTRIBUTING.md) document?
- [x] Have you checked to ensure there aren't other open [Pull Requests](https://github.com/galtm/xslt-accumulator-tools/pulls) for the same update/change?
- [x] Have you squashed any irrelevant commits and commit messages? \[[instructions](https://git-scm.com/book/en/v2/Git-Tools-Rewriting-History)\]
- [x] Do all automated CI/CD checks pass?
