### PR TITLE
bump Java from 11 to 17, plus bump GitHub Actions

### DIFF
--- a/.github/workflows/maven.yml
+++ b/.github/workflows/maven.yml
@@ -20,11 +20,11 @@ jobs:
     runs-on: ubuntu-latest
 
     steps:
-    - uses: actions/checkout@v4
-    - name: Set up JDK 11
-      uses: actions/setup-java@v4
+    - uses: actions/checkout@v5
+    - name: Set up JDK 17
+      uses: actions/setup-java@v5
       with:
-        java-version: '11'
+        java-version: '17'
         distribution: 'temurin'
         cache: maven
     - name: Build with Maven


### PR DESCRIPTION
### Notes

This PR updates dependencies: Java from 11 to 17; GitHub Actions checkout and setup-java from 4 to 5

### Checklist

- [ ] Have you followed the guidelines in our [Contributing](https://github.com/galtm/xslt-accumulator-tools/blob/main/CONTRIBUTING.md) document?
- [x] Have you checked to ensure there aren't other open [Pull Requests](https://github.com/galtm/xslt-accumulator-tools/pulls) for the same update/change?
- [x] Have you squashed any irrelevant commits and commit messages? \[[instructions](https://git-scm.com/book/en/v2/Git-Tools-Rewriting-History)\]
- [x] Do all automated CI/CD checks pass?
